### PR TITLE
Create memos table

### DIFF
--- a/app/Models/Memo.php
+++ b/app/Models/Memo.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Memo extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'title',
+        'content',
+        'user_id',
+    ];
+
+    /**
+     * Get the user that owns the memo.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,6 +6,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class User extends Authenticatable
 {
@@ -44,5 +45,13 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the memos for the user.
+     */
+    public function memos(): HasMany
+    {
+        return $this->hasMany(Memo::class);
     }
 }

--- a/database/migrations/2023_01_01_000003_create_memos_table.php
+++ b/database/migrations/2023_01_01_000003_create_memos_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('memos', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('content');
+            $table->foreignId('user_id')->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('memos');
+    }
+};


### PR DESCRIPTION
Related to #1

Create a new `memos` table and add relationships between `User` and `Memo` models.

* **Migration File**: Add `database/migrations/2023_01_01_000003_create_memos_table.php` to create the `memos` table with columns `id`, `title`, `content`, `user_id`, and `timestamps`.
* **User Model**: Modify `app/Models/User.php` to add a `memos` relationship method.
* **Memo Model**: Add `app/Models/Memo.php` to create a new `Memo` model with `fillable` property and a `user` relationship method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/2?shareId=0c8089c2-f755-48f2-a1a8-498dba04a3fc).