### PR TITLE
Add memo view screen

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -60,4 +60,14 @@ class MemoController extends Controller
 
         return redirect()->route('dashboard');
     }
+
+    /**
+     * Display a list of registered memos.
+     */
+    public function index()
+    {
+        $memos = Memo::where('user_id', Auth::id())->get();
+
+        return view('memos.index', compact('memos'));
+    }
 }

--- a/resources/views/memos/index.blade.php
+++ b/resources/views/memos/index.blade.php
@@ -1,0 +1,25 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+            {{ __('Memos') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
+                <div class="p-6 bg-white border-b border-gray-200">
+                    <a href="{{ route('memos.create') }}" class="text-blue-500">{{ __('Create New Memo') }}</a>
+                    <ul class="mt-4">
+                        @foreach ($memos as $memo)
+                            <li class="mb-4">
+                                <h3 class="text-lg font-semibold">{{ $memo->title }}</h3>
+                                <p>{{ $memo->content }}</p>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ Route::middleware('auth')->group(function () {
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 
+    Route::get('/memos', [MemoController::class, 'index'])->name('memos.index');
     Route::get('/memos/create', [MemoController::class, 'create'])->name('memos.create');
     Route::post('/memos', [MemoController::class, 'store'])->name('memos.store');
     Route::get('/memos/{memo}/edit', [MemoController::class, 'edit'])->name('memos.edit');


### PR DESCRIPTION
Related to #10

Add a screen to view registered memos.

* **MemoController**: Add `index` method to fetch and display registered memos.
* **View**: Create `resources/views/memos/index.blade.php` to display a list of memos with their titles and content, and a link to create a new memo.
* **Routes**: Add a route in `routes/web.php` for viewing registered memos using `MemoController@index` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/11?shareId=1f06b676-fd19-4443-81e5-c2c1a1970000).