### PR TITLE
Add textarea component to fix missing component error

### DIFF
--- a/resources/views/components/textarea.blade.php
+++ b/resources/views/components/textarea.blade.php
@@ -1,0 +1,1 @@
+<textarea {{ $attributes->merge(['class' => 'border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm']) }} @if($attributes->has('required')) required @endif @if($attributes->has('autofocus')) autofocus @endif>{{ $slot }}</textarea>


### PR DESCRIPTION
Related to #12

Add a new `textarea` component to fix the missing component error.

* Create `resources/views/components/textarea.blade.php` with a `textarea` HTML element and support for `required` and `autofocus` attributes.
* Replace the `x-textarea` component reference with the newly created `textarea` component in `resources/views/memos/create.blade.php`.
* Replace the `x-textarea` component reference with the newly created `textarea` component in `resources/views/memos/edit.blade.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/13?shareId=0456ad53-6232-49b2-a480-384c9816620c).