### PR TITLE
Fix registration redirect to list screen

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -38,6 +38,6 @@ class RegisterController extends Controller
 
         Auth::login($user);
 
-        return redirect()->intended('/dashboard');
+        return redirect()->intended(route('memos.index'));
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -45,6 +45,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(route('dashboard', absolute: false));
+        return redirect(route('memos.index', absolute: false));
     }
 }

--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -32,7 +32,7 @@ class MemoController extends Controller
             'user_id' => Auth::id(),
         ]);
 
-        return redirect()->route('dashboard');
+        return redirect()->route('memos.index');
     }
 
     /**
@@ -58,7 +58,7 @@ class MemoController extends Controller
             'content' => $request->content,
         ]);
 
-        return redirect()->route('dashboard');
+        return redirect()->route('memos.index');
     }
 
     /**


### PR DESCRIPTION
Related to #14

Update registration and memo controllers to redirect to list screen after registration or update.

* **RegisteredUserController.php**
  - Update the `store` method to redirect to the `memos.index` route after registration.

* **RegisterController.php**
  - Update the `register` method to redirect to the `memos.index` route after registration.

* **MemoController.php**
  - Update the `store` method to redirect to the `memos.index` route after memo registration.
  - Update the `update` method to redirect to the `memos.index` route after memo update.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/15?shareId=3ad7cfc2-0c2f-40ea-8d0f-87f4acab68f9).