### PR TITLE
Change memo list screen to table format

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -66,7 +66,7 @@ class MemoController extends Controller
      */
     public function index()
     {
-        $memos = Memo::where('user_id', Auth::id())->get();
+        $memos = Memo::with('user')->where('user_id', Auth::id())->get();
 
         return view('memos.index', compact('memos'));
     }

--- a/resources/views/memos/index.blade.php
+++ b/resources/views/memos/index.blade.php
@@ -10,15 +10,30 @@
             <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
                 <div class="p-6 bg-white border-b border-gray-200">
                     <a href="{{ route('memos.create') }}" class="text-blue-500">{{ __('Create New Memo') }}</a>
-                    <ul class="mt-4">
-                        @foreach ($memos as $memo)
-                            <li class="mb-4">
-                                <h3 class="text-lg font-semibold">{{ $memo->title }}</h3>
-                                <p>{{ $memo->content }}</p>
-                                <a href="{{ route('memos.edit', $memo->id) }}" class="text-blue-500">{{ __('Edit') }}</a>
-                            </li>
-                        @endforeach
-                    </ul>
+                    <table class="mt-4 w-full">
+                        <thead>
+                            <tr>
+                                <th class="border px-4 py-2">ID</th>
+                                <th class="border px-4 py-2">Creator</th>
+                                <th class="border px-4 py-2">Title</th>
+                                <th class="border px-4 py-2">Content</th>
+                                <th class="border px-4 py-2">Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach ($memos as $memo)
+                                <tr>
+                                    <td class="border px-4 py-2">{{ $memo->id }}</td>
+                                    <td class="border px-4 py-2">{{ $memo->user->name }}</td>
+                                    <td class="border px-4 py-2">{{ $memo->title }}</td>
+                                    <td class="border px-4 py-2">{{ Str::limit($memo->content, 10, '...') }}</td>
+                                    <td class="border px-4 py-2">
+                                        <a href="{{ route('memos.edit', $memo->id) }}" class="text-blue-500">{{ __('Edit') }}</a>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>

--- a/resources/views/memos/index.blade.php
+++ b/resources/views/memos/index.blade.php
@@ -11,7 +11,7 @@
                 <div class="p-6 bg-white border-b border-gray-200">
                     <a href="{{ route('memos.create') }}" class="text-blue-500">{{ __('Create New Memo') }}</a>
                     <table class="mt-4 w-full">
-                        <thead>
+                        <thead class="bg-gray-200">
                             <tr>
                                 <th class="border px-4 py-2">ID</th>
                                 <th class="border px-4 py-2">Creator</th>


### PR DESCRIPTION
Related to #18

Change the memo list screen from a list format to a table format.

* Replace the `<ul>` and `<li>` elements with a `<table>` element in `resources/views/memos/index.blade.php`.
* Add a `<thead>` element with headers "ID", "Creator", "Title", "Content", and "Action".
* Add a `<tbody>` element with rows for each memo.
* Display the memo details such as ID, creator (user name), title, and truncated content (10 characters with `...` if exceeded).
* Add an action button to navigate to the edit screen in the table format.
* Update the `index` method in `app/Http/Controllers/MemoController.php` to include the `user` relationship when fetching memos.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/19?shareId=64ecf762-e13d-4aa3-bcda-c63f77812f76).