### PR TITLE
Add delete button to memo list

### DIFF
--- a/app/Http/Controllers/MemoController.php
+++ b/app/Http/Controllers/MemoController.php
@@ -70,4 +70,18 @@ class MemoController extends Controller
 
         return view('memos.index', compact('memos'));
     }
+
+    /**
+     * Handle memo deletion.
+     */
+    public function destroy(Memo $memo)
+    {
+        if ($memo->user_id !== Auth::id()) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $memo->delete();
+
+        return redirect()->route('memos.index');
+    }
 }

--- a/resources/views/memos/index.blade.php
+++ b/resources/views/memos/index.blade.php
@@ -29,6 +29,7 @@
                                     <td class="border px-4 py-2">{{ Str::limit($memo->content, 10, '...') }}</td>
                                     <td class="border px-4 py-2">
                                         <a href="{{ route('memos.edit', $memo->id) }}" class="text-blue-500">{{ __('Edit') }}</a>
+                                        <button class="text-red-500 ml-4" onclick="confirmDelete({{ $memo->id }})">{{ __('Delete') }}</button>
                                     </td>
                                 </tr>
                             @endforeach
@@ -38,4 +39,35 @@
             </div>
         </div>
     </div>
+
+    <x-modal name="confirm-delete-modal" :show="false" maxWidth="md">
+        <div class="p-6">
+            <h2 class="text-lg font-medium text-gray-900">
+                {{ __('Are you sure you want to delete this memo?') }}
+            </h2>
+
+            <div class="mt-6 flex justify-end">
+                <x-secondary-button x-on:click="$dispatch('close')">
+                    {{ __('No') }}
+                </x-secondary-button>
+
+                <form method="POST" action="" id="delete-form" class="ml-3">
+                    @csrf
+                    @method('DELETE')
+
+                    <x-primary-button class="ml-3">
+                        {{ __('Yes') }}
+                    </x-primary-button>
+                </form>
+            </div>
+        </div>
+    </x-modal>
+
+    <script>
+        function confirmDelete(memoId) {
+            const form = document.getElementById('delete-form');
+            form.action = `/memos/${memoId}`;
+            window.dispatchEvent(new CustomEvent('open-modal', { detail: 'confirm-delete-modal' }));
+        }
+    </script>
 </x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::middleware('auth')->group(function () {
     Route::post('/memos', [MemoController::class, 'store'])->name('memos.store');
     Route::get('/memos/{memo}/edit', [MemoController::class, 'edit'])->name('memos.edit');
     Route::put('/memos/{memo}', [MemoController::class, 'update'])->name('memos.update');
+    Route::delete('/memos/{memo}', [MemoController::class, 'destroy'])->name('memos.destroy'); // P55ee
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Related to #20

Add delete button and confirmation dialog to memo list screen.

* Add a `destroy` method in `MemoController.php` to handle memo deletion.
* Add a delete button next to the edit button for each memo in `index.blade.php`.
* Add a modal dialog for delete confirmation in `index.blade.php`.
* Use JavaScript to handle the delete button click event and show the confirmation dialog.
* Add a route for memo deletion in `web.php`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/t2aking/simple_memo/pull/22?shareId=cc150749-6db6-4c94-a935-f9febd832e75).